### PR TITLE
Fix ContentMapper update with example

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/mapper/ContentMapper.java
+++ b/wiki/src/main/java/com/matt/wiki/mapper/ContentMapper.java
@@ -25,7 +25,7 @@ public interface ContentMapper {
 
     int updateByExampleSelective(@Param("row") Content row, @Param("example") ContentExample example);
 
-    int updateByExampleWithBLOBs(@Param("row") Content row);
+    int updateByExampleWithBLOBs(@Param("row") Content row, @Param("example") ContentExample example);
 
     int updateByExample(@Param("row") Content row, @Param("example") ContentExample example);
 

--- a/wiki/src/main/java/com/matt/wiki/service/DocService.java
+++ b/wiki/src/main/java/com/matt/wiki/service/DocService.java
@@ -79,7 +79,7 @@ public class DocService {
             contentMapper.insert(contentSave);
         }else{
             docMapper.updateByPrimaryKey(docSave);
-            int count = contentMapper.updateByExampleWithBLOBs(contentSave);
+            int count = contentMapper.updateByPrimaryKeyWithBLOBs(contentSave);
             if(count == 0){
                 contentMapper.insert(contentSave);
             }


### PR DESCRIPTION
## Summary
- fix `ContentMapper.updateByExampleWithBLOBs` signature
- update DocService to use `updateByPrimaryKeyWithBLOBs`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888b6f85c248328a0ff2ca91e7e7593