### PR TITLE
Fix copy utility function

### DIFF
--- a/wiki/web/src/util/tool.ts
+++ b/wiki/web/src/util/tool.ts
@@ -21,10 +21,11 @@ export class Tool {
    * 对象复制
    * @param obj
    */
-  public static copy (obj: object) {
-    if (Tool.isNotEmpty(obj)) {
-      return JSON.parse(JSON.stringify(obj));
+  public static copy (obj: any) {
+    if (obj === null || obj === undefined) {
+      return obj;
     }
+    return JSON.parse(JSON.stringify(obj));
   }
 
   /**


### PR DESCRIPTION
## Summary
- handle empty objects/arrays in `Tool.copy` to avoid undefined results

## Testing
- `npm install` *(fails: `registry.npmjs.org` blocked)*
- `npm run lint` *(fails: `vue-cli-service` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893d55d3f08328b8c79c3dab06816f