### PR TITLE
Fix MD5 script inclusion

### DIFF
--- a/wiki/web/public/index.html
+++ b/wiki/web/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <script href="<%= BASE_URL %>js/md5.js"></script>
+    <script src="<%= BASE_URL %>js/md5.js"></script>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/wiki/web/src/global.d.ts
+++ b/wiki/web/src/global.d.ts
@@ -1,0 +1,2 @@
+declare function hexMd5(s: string): string;
+declare const KEY: string;


### PR DESCRIPTION
## Summary
- fix script tag in `index.html` so `md5.js` loads correctly
- add TypeScript declarations for global `hexMd5` and `KEY`

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad88730dc8328a568d2a27a7c4e2c