### PR TITLE
Fix reset password modal closing

### DIFF
--- a/wiki/web/src/views/admin/admin-user.vue
+++ b/wiki/web/src/views/admin/admin-user.vue
@@ -234,6 +234,7 @@ export default defineComponent({
         const data = response.data; // data = commonResp
         if (data.success) {
           resetModel.loading = false;
+          resetModel.visible = false;
 
           // 重新加载列表
           handleQuery({


### PR DESCRIPTION
## Summary
- close reset password modal after success

## Testing
- `mvn test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688ae232a42083288b8173d1a58e4825