### PR TITLE
Fix header login modal placement and password error message

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/service/UserService.java
+++ b/wiki/src/main/java/com/matt/wiki/service/UserService.java
@@ -124,20 +124,19 @@ public class UserService {
     public UserLoginResp login(UserLoginReq req) {
         User userDB = selectByLoginName(req.getLoginName());
 
-        if(ObjectUtils.isEmpty(userDB)){
+        if (ObjectUtils.isEmpty(userDB)) {
 //            用户名不存在
-            LOG.warn("User not found for login name: " + req.getLoginName());
-            throw new BusinessException(BusinessExceptionCode.USER_LOGIN_NAME_EXIST);
-        }else{
-            if(userDB.getPassword().equals(req.getPassword())){
+            LOG.warn("User not found for login name: {}", req.getLoginName());
+            throw new BusinessException(BusinessExceptionCode.LOGIN_USER_ERROR);
+        } else {
+            if (userDB.getPassword().equals(req.getPassword())) {
 //                登录成功
                 UserLoginResp userLoginResp = CopyUtil.copy(userDB, UserLoginResp.class);
                 return userLoginResp;
-            }else{
+            } else {
 //                密码不对
-                LOG.warn("密码不对，输入密码：{}, 数据库密码：{}",req.getPassword(), userDB.getPassword());
-                throw new BusinessException(BusinessExceptionCode.USER_LOGIN_NAME_EXIST);
-
+                LOG.warn("密码不对，输入密码：{}, 数据库密码：{}", req.getPassword(), userDB.getPassword());
+                throw new BusinessException(BusinessExceptionCode.LOGIN_USER_ERROR);
             }
         }
     }

--- a/wiki/web/src/components/the-header.vue
+++ b/wiki/web/src/components/the-header.vue
@@ -22,24 +22,27 @@
       <a-menu-item key="/about">
         <router-link to="/about">About Us</router-link>
       </a-menu-item>
+    </a-menu>
 
+    <div class="login-area">
       <a-popconfirm
           title="确认退出登录?"
           ok-text="是"
           cancel-text="否"
           @confirm="logout()"
+          v-if="user.id"
       >
-        <a class="login-menu" v-show="loginConfig.user.id">
+        <a class="login-menu">
           <span>退出登录</span>
         </a>
       </a-popconfirm>
-      <a class="login-menu" v-show="loginConfig.user.id">
-        <span>您好：{{loginConfig.user.name}}</span>
+      <a class="login-menu" v-if="user.id">
+        <span>您好：{{user.name}}</span>
       </a>
-      <a class="login-menu" v-show="!loginConfig.user.id" @click="showLoginModal">
+      <a class="login-menu" v-else @click="showLoginModal">
         <span>登录</span>
       </a>
-    </a-menu>
+    </div>
 
 
     <a-modal
@@ -127,7 +130,7 @@ export default defineComponent({
       });
     };
 
-    return {
+  return {
       showLoginModal,
       loginConfig,
       login,
@@ -140,8 +143,11 @@ export default defineComponent({
 </script>
 
 <style>
-.login-menu{
+.login-area {
   float: right;
+}
+.login-menu {
   color: white;
+  margin-left: 16px;
 }
 </style>


### PR DESCRIPTION
## Summary
- move header login controls into a dedicated container so the login modal opens from the correct position
- return the proper error when a login attempt fails due to bad credentials

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM for com.Matt:wiki:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_688e73c30bc883289ff0b587eb364221