### PR TITLE
Fix login popup alignment in header

### DIFF
--- a/wiki/web/src/components/the-header.vue
+++ b/wiki/web/src/components/the-header.vue
@@ -143,7 +143,7 @@ export default defineComponent({
 
 <style>
 .login-area {
-  float: right;
+  margin-left: auto;
 }
 
 .login-menu {


### PR DESCRIPTION
## Summary
- align login area in header using flex-friendly margin

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e776287ac8328b3e8f746eccc00d0