### PR TITLE
fix: isolate tests from external services

### DIFF
--- a/wiki/pom.xml
+++ b/wiki/pom.xml
@@ -35,11 +35,17 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/wiki/src/test/java/com/matt/wiki/WikiApplicationTests.java
+++ b/wiki/src/test/java/com/matt/wiki/WikiApplicationTests.java
@@ -2,12 +2,19 @@ package com.matt.wiki;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class WikiApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @MockBean
+    private RedisTemplate<?, ?> redisTemplate;
+
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/wiki/src/test/resources/application-test.properties
+++ b/wiki/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+mybatis.mapper-locations=classpath:/mapper/**/*.xml
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration


### PR DESCRIPTION
## Summary
- add H2 and test profile to avoid using external MySQL/Redis during tests
- mock RedisTemplate to allow Spring context loading

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.Matt:wiki:0.0.1-SNAPSHOT)*


------
https://chatgpt.com/codex/tasks/task_e_688fddc8bcc08328a465ef082d9f3596