### PR TITLE
fix: correct EbookSnapshot mapper namespace

### DIFF
--- a/wiki/src/main/resources/mapper/EbookSnapshotMapperCust.xml
+++ b/wiki/src/main/resources/mapper/EbookSnapshotMapperCust.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
-<mapper namespace="com.jiawa.wiki.mapper.EbookSnapshotMapperCust" >
+<mapper namespace="com.matt.wiki.mapper.EbookSnapshotMapperCust" >
 
     <!--
     # 方案一（ID不连续）：


### PR DESCRIPTION
## Summary
- fix namespace mismatch in `EbookSnapshotMapperCust.xml` so MyBatis can locate mapper methods

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.Matt:wiki:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68900745df088328acf677daa6af82d3