### PR TITLE
Avoid WebSocket bean during tests

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/config/WebSocketConfig.java
+++ b/wiki/src/main/java/com/matt/wiki/config/WebSocketConfig.java
@@ -2,9 +2,11 @@ package com.matt.wiki.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 @Configuration
+@Profile("!test")
 
 public class WebSocketConfig {
 


### PR DESCRIPTION
## Summary
- avoid WebSocket bean creation when the `test` profile is active

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.5.3 – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68913af0bd488328915e9534d0e23b47