### PR TITLE
fix(build): guard TypeScript performance overrides

### DIFF
--- a/wiki/web/package.json
+++ b/wiki/web/package.json
@@ -7,7 +7,8 @@
     "serve-prod": "vue-cli-service serve --mode prod",
     "build-dev": "vue-cli-service build --mode dev",
     "build-prod": "vue-cli-service build --mode prod",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "postinstall": "node scripts/patch-fork-ts-checker.js"
   },
   "dependencies": {
     "@ant-design/icons-vue": "^7.0.1",

--- a/wiki/web/scripts/patch-fork-ts-checker.js
+++ b/wiki/web/scripts/patch-fork-ts-checker.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.resolve(__dirname, '../node_modules/fork-ts-checker-webpack-plugin-v5/lib/typescript-reporter/profile/TypeScriptPerformance.js');
+
+try {
+  if (fs.existsSync(filePath)) {
+    let content = fs.readFileSync(filePath, 'utf8');
+    if (content.includes('const { mark, measure } = typeScriptPerformance;') && !content.includes('markDescriptor')) {
+      content = content.replace(
+        'const { mark, measure } = typeScriptPerformance;\n        const { enable, disable } = performance;\n        typeScriptPerformance.mark = (name) => {\n            mark(name);\n            performance.mark(name);\n        };\n        typeScriptPerformance.measure = (name, startMark, endMark) => {\n            measure(name, startMark, endMark);\n            performance.measure(name, startMark, endMark);\n        };',
+        'const { mark, measure } = typeScriptPerformance;\n        const { enable, disable } = performance;\n        const markDescriptor = Object.getOwnPropertyDescriptor(typeScriptPerformance, \'mark\');\n        const measureDescriptor = Object.getOwnPropertyDescriptor(typeScriptPerformance, \'measure\');\n        if (markDescriptor && markDescriptor.writable) {\n            typeScriptPerformance.mark = (name) => {\n                mark(name);\n                performance.mark(name);\n            };\n        }\n        if (measureDescriptor && measureDescriptor.writable) {\n            typeScriptPerformance.measure = (name, startMark, endMark) => {\n                measure(name, startMark, endMark);\n                performance.measure(name, startMark, endMark);\n            };\n        }'
+      );
+      fs.writeFileSync(filePath, content, 'utf8');
+      console.log('Patched fork-ts-checker-webpack-plugin TypeScriptPerformance.');
+    } else {
+      console.log('TypeScriptPerformance already patched or unexpected content.');
+    }
+  }
+} catch (err) {
+  console.error('Failed to patch fork-ts-checker-webpack-plugin', err);
+}


### PR DESCRIPTION
## Summary
- patch fork-ts-checker performance hooks to respect read-only properties
- run patch script after install to avoid TypeError during Vue build

## Testing
- `npm run build-prod` *(fails: Property 'content' does not exist on type)*

------
https://chatgpt.com/codex/tasks/task_e_6891468129d483288312fde6916c5d35