### PR TITLE
Add Qwen chat model configuration

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/config/AiModelConfig.java
+++ b/wiki/src/main/java/com/matt/wiki/config/AiModelConfig.java
@@ -1,0 +1,28 @@
+package com.matt.wiki.config;
+
+import com.matt.wiki.util.TestUtil;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiModelConfig {
+
+    @Bean
+    public TestUtil testUtil() {
+        return new TestUtil();
+    }
+
+    @Bean(name = "qwenChatModel")
+    public ChatLanguageModel qwenChatModel(ChatLanguageModel chatLanguageModel) {
+        return chatLanguageModel;
+    }
+
+    @Bean(name = "qwenStreamingChatModel")
+    public StreamingChatLanguageModel qwenStreamingChatModel(
+            StreamingChatLanguageModel streamingChatLanguageModel) {
+        return streamingChatLanguageModel;
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure Qwen chat and streaming model beans
- expose TestUtil for AI tool usage

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acc6425cec8328ad5ac2a5800e24c6