### PR TITLE
Align AiAssistant bean names with Qwen auto-config

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/aiservice/AiAssistant.java
+++ b/wiki/src/main/java/com/matt/wiki/aiservice/AiAssistant.java
@@ -7,8 +7,8 @@ import dev.langchain4j.service.spring.AiService;
 import dev.langchain4j.service.spring.AiServiceWiringMode;
 import reactor.core.publisher.Flux;
 
-@AiService(wiringMode = AiServiceWiringMode.EXPLICIT, chatModel = "qwenChatModel",
-        streamingChatModel = "qwenStreamingChatModel", chatMemoryProvider = "chatMemoryProvider", tools = "testUtil")
+@AiService(wiringMode = AiServiceWiringMode.EXPLICIT, chatModel = "QwenChatModel",
+        streamingChatModel = "QwenStreamingChatModel", chatMemoryProvider = "chatMemoryProvider", tools = "testUtil")
 public interface AiAssistant {
 
     String chat(@MemoryId  String id, @UserMessage String message);


### PR DESCRIPTION
## Summary
- reference `QwenChatModel` and `QwenStreamingChatModel` beans in AiAssistant

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acd608aed08328a5f7ac3d9f442dac