### PR TITLE
Avoid serializing reactive types in logging

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/aspect/LogAspect.java
+++ b/wiki/src/main/java/com/matt/wiki/aspect/LogAspect.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
+import org.reactivestreams.Publisher;
 
 @Aspect
 @Component
@@ -58,16 +59,20 @@ public class LogAspect {
 
         // 打印请求参数
         Object[] args = joinPoint.getArgs();
-		// LOG.info("请求参数: {}", JSONObject.toJSONString(args));
+        // LOG.info("请求参数: {}", JSONObject.toJSONString(args));
 
-		Object[] arguments  = new Object[args.length];
+        Object[] arguments  = new Object[args.length];
         for (int i = 0; i < args.length; i++) {
             if (args[i] instanceof ServletRequest
                     || args[i] instanceof ServletResponse
                     || args[i] instanceof MultipartFile) {
                 continue;
             }
-            arguments[i] = args[i];
+            if (args[i] instanceof Publisher) {
+                arguments[i] = args[i].getClass().getSimpleName();
+            } else {
+                arguments[i] = args[i];
+            }
         }
         // 排除字段，敏感字段或太长的字段不显示
         String[] excludeProperties = {"password", "file"};
@@ -87,7 +92,11 @@ public class LogAspect {
         PropertyPreFilters filters = new PropertyPreFilters();
         PropertyPreFilters.MySimplePropertyPreFilter excludefilter = filters.addFilter();
         excludefilter.addExcludes(excludeProperties);
-        LOG.info("返回结果: {}", JSONObject.toJSONString(result, excludefilter));
+        if (result instanceof Publisher) {
+            LOG.info("返回结果: {}", result.getClass().getSimpleName());
+        } else {
+            LOG.info("返回结果: {}", JSONObject.toJSONString(result, excludefilter));
+        }
         LOG.info("------------- 结束 耗时：{} ms -------------", System.currentTimeMillis() - startTime);
         return result;
     }


### PR DESCRIPTION
## Summary
- Skip Fastjson serialization for reactive Publisher instances in request and response logging
- Log Publisher class names instead to prevent `UnsupportedOperationException`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ace12962588328a33c7230e0e8290c