### PR TITLE
fix: 解析AI意图输出失败

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/aioutput/IntentionOutput.java
+++ b/wiki/src/main/java/com/matt/wiki/aioutput/IntentionOutput.java
@@ -1,9 +1,15 @@
 package com.matt.wiki.aioutput;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import dev.langchain4j.model.output.structured.Description;
 import lombok.Data;
 
+/**
+ * AI注册意图输出结果，由于AI返回的JSON中可能会包含其他字段，为了避免解析失败，
+ * 将未知字段记录为忽略。
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 public class IntentionOutput {
 

--- a/wiki/src/main/java/com/matt/wiki/service/impl/AiChatServiceImpl.java
+++ b/wiki/src/main/java/com/matt/wiki/service/impl/AiChatServiceImpl.java
@@ -37,8 +37,12 @@ public class AiChatServiceImpl implements AiChatService {
 //        用户意图
         IntentionOutput intention = aiIntentionAssistant.intention(userId, message);
         LOG.info("----" + intention);
+        Integer intent = intention.getIntention();
+        if (intent == null) {
+            return Flux.just(intention.getOutput());
+        }
         String output = intention.getOutput();
-        switch (intention.getIntention()){
+        switch (intent){
             case 1 :
 //                    1.预约
                 output = guestRegister(userId,message);
@@ -58,7 +62,7 @@ public class AiChatServiceImpl implements AiChatService {
             default :
                 return Flux.just(intention.getOutput());
         }
-        return Flux.just(intention.getOutput());
+        return Flux.just(output);
     }
 
     private String guestRegister(String userId, String message){


### PR DESCRIPTION
## Summary
- 忽略AI意图结果中的未知字段，避免解析失败
- 处理意图字段缺失时的空指针问题

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad04648fc883289c183e376987aef4