### PR TITLE
fix: 解析AI意图输出失败

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/aioutput/GuestRegisterOutput.java
+++ b/wiki/src/main/java/com/matt/wiki/aioutput/GuestRegisterOutput.java
@@ -1,9 +1,11 @@
 package com.matt.wiki.aioutput;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import dev.langchain4j.model.output.structured.Description;
 import lombok.Data;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 public class GuestRegisterOutput {
 
@@ -32,6 +34,6 @@ public class GuestRegisterOutput {
     private String urgency;
 
     @Description("是否完成登记")
-    private Boolean completed;
+    private String completed;
 
 }

--- a/wiki/src/main/java/com/matt/wiki/aioutput/IntentionOutput.java
+++ b/wiki/src/main/java/com/matt/wiki/aioutput/IntentionOutput.java
@@ -1,9 +1,15 @@
 package com.matt.wiki.aioutput;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import dev.langchain4j.model.output.structured.Description;
 import lombok.Data;
 
+/**
+ * AI注册意图输出结果，由于AI返回的JSON中可能会包含其他字段，为了避免解析失败，
+ * 将未知字段记录为忽略。
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 public class IntentionOutput {
 

--- a/wiki/src/main/java/com/matt/wiki/service/impl/AiChatServiceImpl.java
+++ b/wiki/src/main/java/com/matt/wiki/service/impl/AiChatServiceImpl.java
@@ -37,8 +37,12 @@ public class AiChatServiceImpl implements AiChatService {
 //        用户意图
         IntentionOutput intention = aiIntentionAssistant.intention(userId, message);
         LOG.info("----" + intention);
+        Integer intent = intention.getIntention();
+        if (intent == null) {
+            return Flux.just(intention.getOutput());
+        }
         String output = intention.getOutput();
-        switch (intention.getIntention()){
+        switch (intent){
             case 1 :
 //                    1.预约
                 output = guestRegister(userId,message);
@@ -58,16 +62,18 @@ public class AiChatServiceImpl implements AiChatService {
             default :
                 return Flux.just(intention.getOutput());
         }
-        return Flux.just(intention.getOutput());
+        return Flux.just(output);
     }
 
     private String guestRegister(String userId, String message){
         GuestRegisterOutput guestRegisterOutput = aiAssistant.guestRegister(userId,message);
         LOG.info("----" + guestRegisterOutput);
-        if(guestRegisterOutput.getCompleted()){
-//持久化层数据库
+        String completed = guestRegisterOutput.getCompleted();
+        if ("yes".equalsIgnoreCase(completed) || "true".equalsIgnoreCase(completed)) {
+            // 持久化层数据库
             GuestRegisterEntity entity = new GuestRegisterEntity();
-            BeanUtils.copyProperties(guestRegisterOutput,entity);
+            BeanUtils.copyProperties(guestRegisterOutput, entity);
+            entity.setCompleted(Boolean.TRUE);
             guestRegisterRepository.save(entity);
 
         }


### PR DESCRIPTION
## Summary
- 忽略访客登记结果中的未知字段并将完成标志改为字符串
- 仅在返回“yes/true”时持久化访客登记信息

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad04648fc883289c183e376987aef4