### PR TITLE
Fix chat history repository method naming

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/repository/ChatHistoryRepository.java
+++ b/wiki/src/main/java/com/matt/wiki/repository/ChatHistoryRepository.java
@@ -11,5 +11,5 @@ public interface ChatHistoryRepository extends BaseRepository<ChatHistoryEntity>
      * @param sessionId
      * @return
      */
-    List<ChatHistoryEntity> findByTop20SessionIdOderByIdDesc(String sessionId);
+    List<ChatHistoryEntity> findTop20BySessionIdOrderByIdDesc(String sessionId);
 }

--- a/wiki/src/main/java/com/matt/wiki/util/ChatHistoryTools.java
+++ b/wiki/src/main/java/com/matt/wiki/util/ChatHistoryTools.java
@@ -25,7 +25,7 @@ public class ChatHistoryTools {
 
 
         List<ChatHistory> result = new ArrayList<>();
-        List<ChatHistoryEntity> entityList = chatHistoryRepository.findByTop20SessionIdOderByIdDesc(sessionId);
+        List<ChatHistoryEntity> entityList = chatHistoryRepository.findTop20BySessionIdOrderByIdDesc(sessionId);
 
         for(ChatHistoryEntity entity: entityList){
             ChatHistory history = new ChatHistory();


### PR DESCRIPTION
## Summary
- correct ChatHistoryRepository query method name
- update ChatHistoryTools to use new method

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68adbec46b588328840675d0d5a1a1df