### PR TITLE
Use SnowFlake for user ID generation in AI controller

### DIFF
--- a/wiki/src/main/java/com/matt/wiki/controller/AiController.java
+++ b/wiki/src/main/java/com/matt/wiki/controller/AiController.java
@@ -4,6 +4,7 @@ package com.matt.wiki.controller;
 import com.matt.wiki.aiservice.AiAssistant;
 import com.matt.wiki.service.AiChatService;
 import com.matt.wiki.vo.ChatHistoryVo;
+import com.matt.wiki.util.SnowFlake;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -24,23 +25,35 @@ public class AiController {
     @Autowired
     private AiChatService aiChatService;
 
+    @Autowired
+    private SnowFlake snowFlake;
+
 //    @GetMapping("/chat")
 //    public String chat(
 //            @RequestParam(value = "message", defaultValue = "Hello") String message,
-//            @RequestParam(value = "userId", defaultValue = "111") String userId) {
+//            @RequestParam(value = "userId", required = false) String userId) {
+//        if (userId == null || userId.isEmpty()) {
+//            userId = String.valueOf(snowFlake.nextId());
+//        }
 //        return aiAssistant.chat(userId, message);
 //    }
 
     @GetMapping(value = "/chat-stream", produces = MediaType.TEXT_PLAIN_VALUE + ";charset=utf-8")
     public Flux<String> chatStream(
             @RequestParam(value = "message", defaultValue = "Hello") String message,
-            @RequestParam(value = "userId", defaultValue = "111") String userId) {
+            @RequestParam(value = "userId", required = false) String userId) {
+        if (userId == null || userId.isEmpty()) {
+            userId = String.valueOf(snowFlake.nextId());
+        }
         return Flux.just(aiChatService.chatStream(userId, message));
     }
 
     @GetMapping(value = "/chat-history")
-    public PagedModel<ChatHistoryVo> queryChatHistory(@RequestParam(value = "userId", defaultValue = "111") String userId,
+    public PagedModel<ChatHistoryVo> queryChatHistory(@RequestParam(value = "userId", required = false) String userId,
                                                       @PageableDefault(direction = Sort.Direction.DESC, sort = "id") Pageable page) {
+        if (userId == null || userId.isEmpty()) {
+            userId = String.valueOf(snowFlake.nextId());
+        }
         return new PagedModel<>(aiChatService.queryChatHistory(userId, page));
     }
 


### PR DESCRIPTION
## Summary
- generate user IDs via SnowFlake rather than using the placeholder 111

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.Matt:wiki:0.0.1-SNAPSHOT: ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae46d847e88328aed1eb702a5e90ba